### PR TITLE
Create validation + syncing workflows for OpenAPI definition

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,22 @@
+# This GitHub Actions workflow syncs the OpenAPI file at openapi.yml to ReadMe
+# It uses the `rdme` GitHub Action to do this: https://docs.readme.com/docs/rdme#github-actions-usage
+# View the resulting docs here: https://wow.readme.io
+name: Validate OpenAPI
+
+# Run workflow for every push to the `main` branch
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout this repo
+        uses: actions/checkout@v3
+
+      - name: Sync openapi.yml to ReadMe
+        uses: readmeio/rdme@7.2.0
+        with:
+          rdme: openapi openapi.yml --key=${{ secrets.README_API_KEY }} --id=6271baa5fa5313003d4a61f2

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,7 +1,7 @@
 # This GitHub Actions workflow syncs the OpenAPI file at openapi.yml to ReadMe
 # It uses the `rdme` GitHub Action to do this: https://docs.readme.com/docs/rdme#github-actions-usage
 # View the resulting docs here: https://wow.readme.io
-name: Validate OpenAPI
+name: Sync OpenAPI to ReadMe
 
 # Run workflow for every push to the `main` branch
 on:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,18 @@
+# This GitHub Actions workflow validates the OpenAPI file at openapi.yml
+# It uses the `rdme` GitHub Action to do this: https://docs.readme.com/docs/rdme#github-actions-usage
+name: Validate OpenAPI
+
+# Run workflow on every push
+on: push
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout this repo
+        uses: actions/checkout@v3
+
+      - name: Validate openapi.yml
+        uses: readmeio/rdme@7.2.0
+        with:
+          rdme: validate openapi.yml

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -66,6 +66,16 @@ const App = () => {
           movies.
           <br />
           <br />
+          <a href="https://wow.readme.io" rel="noreferrer noopener">
+            View the full API docs
+          </a>{" "}
+          (powered by{" "}
+          <a href="https://readme.com" rel="noreferrer noopener">
+            ReadMe 🦉
+          </a>
+          )
+          <br />
+          <br />
           <u className="read_more" onClick={toggleMore}>
             Read more
           </u>

--- a/openapi.yml
+++ b/openapi.yml
@@ -24,7 +24,6 @@ paths:
           example: 5
           schema:
             type: integer
-            format: int32
         - name: year
           in: query
           description: Retrieve a random "wow" from a specific year.
@@ -32,7 +31,6 @@ paths:
           example: 2011
           schema:
             type: integer
-            format: int32
         - name: movie
           in: query
           description: Retrieve a random "wow" by the name of the movie it appears in.
@@ -54,7 +52,6 @@ paths:
           example: 2
           schema:
             type: integer
-            format: int32
         - name: sort
           in: query
           description: Sort multiple random results by either movie, release_date, year, director, or number_current_wow.
@@ -96,7 +93,7 @@ paths:
             range:
               value: 3-7
           schema:
-            type: integer
+            type: string
       responses:
         "200":
           description: Either a single movie or an array of movies
@@ -151,7 +148,6 @@ components:
           example: Midnight in Paris
         year:
           type: integer
-          format: int64
           example: 2011
         release_date:
           type: string

--- a/openapi.yml
+++ b/openapi.yml
@@ -103,6 +103,16 @@ paths:
                 oneOf:
                   - $ref: "#/components/schemas/Wow"
                   - $ref: "#/components/schemas/Wows"
+        "400":
+          description: Bad Request
+          content:
+            text/html:
+              schema:
+                type: string
+              examples:
+                response:
+                  summary: Invalid index input
+                  value: "400 Bad Request: Index should be a number or a range between two numbers"
   /movies:
     get:
       summary: All Movies

--- a/openapi.yml
+++ b/openapi.yml
@@ -40,7 +40,7 @@ paths:
           example: zoolander
           schema:
             type: string
-        - name: directory
+        - name: director
           in: query
           description: Retrieve a random "wow" from a movie with a particular director.
           required: false


### PR DESCRIPTION
This PR is a follow-up to #9 with some OpenAPI-related tasks:
- [x] Creates a workflow for syncing the OpenAPI file to ReadMe on every push to the `main` branch
  - [x] Before you merge this PR in, you'll want to [create a new GitHub secret containing the ReadMe API key](https://docs.readme.com/docs/rdme#example-using-github-secrets) so this workflow can operate as expected. I sent you an email with more information on this!
- [x] Creates a workflow for validating the OpenAPI file on every push
- [x] Links out to the API docs from the website

I have the workflows running successfully in my fork, you can see examples of their successful runs here:
- Sync: https://github.com/kanadgupta/owen-wilson-wow-api/actions/runs/2270623650
- Validate: https://github.com/kanadgupta/owen-wilson-wow-api/actions/runs/2270623646

I also did some additional housekeeping in the OpenAPI file:
- [x] I discovered that [the Ordered Wow endpoint](https://wow.readme.io/reference/ordered) can return a 400 so I added some documentation on that
- [x] Fixes a tiny typo with one of the query parameters in the OpenAPI definition
- [x] Cleans up some unnecessary integer formats

Since I set up the syncing workflow on my fork, these changes are live on the ReadMe docs if you want to take a look: https://wow.readme.io/reference/ordered